### PR TITLE
Added a missing case to match an empty string

### DIFF
--- a/src/main/java/com/imsweb/validation/functions/MetafileContextFunctions.java
+++ b/src/main/java/com/imsweb/validation/functions/MetafileContextFunctions.java
@@ -914,7 +914,7 @@ public class MetafileContextFunctions extends StagingContextFunctions {
         // looks like Genedits considers a regex for a single space to match an empty string...
         if (val.isEmpty()) {
             String tmp = _GEN_MATCH_P2.matcher(reg).replaceAll("\\\\s"); // let's deal only with single spaces, since they seem to do the same in the Genedits language
-            if (tmp.equals("\\s") || tmp.startsWith("\\s|") || tmp.endsWith("|\\s") || tmp.equals("(\\s)") || tmp.startsWith("(\\s|") || tmp.endsWith("|\\s)"))
+            if (tmp.equals("\\s") || tmp.startsWith("\\s|") || tmp.endsWith("|\\s") || tmp.equals("(\\s)") || tmp.endsWith("|(\\s)") || tmp.startsWith("(\\s|") || tmp.endsWith("|\\s)"))
                 return true;
         }
 


### PR DESCRIPTION
If the regex for GEN_MATCH looks like "(1)|(\\s)" (found in edit NAACCR-00717: Edit Over-rides (SEER REVIEWFL)), the current form fails the edit when it should not.