### PR TITLE
Fixes for edits that pass in an null string for empty and that have a grouped whitespace in the regex.

### DIFF
--- a/src/main/java/com/imsweb/validation/functions/MetafileContextFunctions.java
+++ b/src/main/java/com/imsweb/validation/functions/MetafileContextFunctions.java
@@ -899,8 +899,10 @@ public class MetafileContextFunctions extends StagingContextFunctions {
     }
 
     public boolean GEN_MATCH(Object value, Object regex) {
-        if (value == null)
-            return false;
+        // sometimes blanks get passed as null. Genedits seems to allow these edits to run.
+        if (value == null) {
+            value = "";
+        }
 
         String val = GEN_TO_STRING(value);
         String reg = GEN_TO_STRING(regex);


### PR DESCRIPTION
This resolves issues with edit id="NCFD-00144" name="Edit Over-rides (SEER REVIEWFL)" not passing for cases with empty overrides. Replaces PR#49